### PR TITLE
Code cleanup

### DIFF
--- a/MateExtensions/som/interpreter/MateNode.java
+++ b/MateExtensions/som/interpreter/MateNode.java
@@ -1,0 +1,10 @@
+package som.interpreter;
+
+
+public interface MateNode {
+  /**
+   * If necessary, this method wraps the node, and replaces it in the AST with
+   * the wrapping node.
+   */
+  void wrapIntoMateNode();
+}

--- a/MateExtensions/som/interpreter/MateifyVisitor.java
+++ b/MateExtensions/som/interpreter/MateifyVisitor.java
@@ -3,69 +3,13 @@ package som.interpreter;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.NodeVisitor;
 
-import som.interpreter.nodes.ArgumentReadNode.LocalArgumentReadNode;
-import som.interpreter.nodes.ArgumentReadNode.NonLocalArgumentReadNode;
-import som.interpreter.nodes.ContextualNode;
-import som.interpreter.nodes.GlobalNode;
-import som.interpreter.nodes.MateAbstractExpressionNode;
-import som.interpreter.nodes.ReturnNonLocalNode.CatchNonLocalReturnNode;
-import som.interpreter.nodes.ReturnNonLocalNode.ReturnLocalNode;
-import som.interpreter.nodes.SOMNode;
-import som.interpreter.nodes.SequenceNode;
-import som.interpreter.nodes.literals.LiteralNode;
-import som.interpreter.nodes.specialized.whileloops.WhileCache;
-import som.interpreter.objectstorage.FieldAccessorNode;
-import som.interpreter.objectstorage.FieldAccessorNode.AbstractReadFieldNode;
-import som.interpreter.objectstorage.FieldAccessorNode.AbstractWriteFieldNode;
-import som.primitives.GlobalPrim;
-import som.primitives.HasGlobalPrim;
-import som.primitives.reflection.PerformInSuperclassPrim;
-import som.primitives.reflection.PerformWithArgumentsInSuperclassPrim;
-import som.primitives.reflection.PerformWithArgumentsPrim;
-
 
 public class MateifyVisitor implements NodeVisitor {
 
-  public boolean visit(Node node) {
-    Node matenode = null;
-    if (
-        (
-            (node instanceof FieldAccessorNode)
-        )
-   || (
-            (node instanceof SOMNode) && 
-            !(node instanceof ContextualNode) && 
-            !(node instanceof MateAbstractExpressionNode) &&
-            !(node instanceof CatchNonLocalReturnNode) &&
-            !(node instanceof ReturnLocalNode) &&
-            !(node instanceof SequenceNode) &&
-            !(node instanceof WhileCache) &&
-            !(node instanceof Primitive) &&
-            !(node instanceof PerformWithArgumentsPrim) &&
-            !(node instanceof PerformWithArgumentsInSuperclassPrim) &&
-            !(node instanceof PerformInSuperclassPrim) &&
-            !(node instanceof HasGlobalPrim) &&
-            !(node instanceof GlobalPrim) &&
-            !(node instanceof LiteralNode) &&
-            !(node instanceof LocalArgumentReadNode) &&
-            !(node instanceof NonLocalArgumentReadNode) &&
-            !(node instanceof GlobalNode)
-       )
-       ){
-      if (node instanceof SOMNode){
-        matenode = ((SOMNode) node).wrapIntoMateNode();
-      } else {
-        if (node instanceof AbstractWriteFieldNode){
-          matenode = ((AbstractWriteFieldNode) node).wrapIntoMateNode();
-        } else {
-          if (node instanceof AbstractReadFieldNode){
-            matenode = ((AbstractReadFieldNode) node).wrapIntoMateNode();
-          } else {
-            matenode = ((SOMNode) node).wrapIntoMateNode();
-          }
-        }
-      }
-      node.replace(matenode);
+  @Override
+  public boolean visit(final Node node) {
+    if (node instanceof MateNode) {
+      ((MateNode) node).wrapIntoMateNode();
     }
     return true;
   }

--- a/MateExtensions/som/interpreter/nodes/MateAbstractExpressionNode.java
+++ b/MateExtensions/som/interpreter/nodes/MateAbstractExpressionNode.java
@@ -17,7 +17,7 @@ import com.oracle.truffle.api.dsl.NodeChildren;
 import com.oracle.truffle.api.dsl.ShortCircuit;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.source.SourceSection;
 
 @NodeChildren({
   @NodeChild(value = "receiver", type = MateAbstractReceiverNode.class),
@@ -29,8 +29,8 @@ public abstract class MateAbstractExpressionNode extends ExpressionNode {
   protected Object doMateDispatchNode(final VirtualFrame frame, final SMateEnvironment environment, final SObject receiver){return null;}
   protected Object doBaseSOMNode(final VirtualFrame frame){return null;}
 
-  public MateAbstractExpressionNode(final Node node){
-    super(node.getSourceSection());
+  public MateAbstractExpressionNode(final SourceSection source){
+    super(source);
   }
 
   /*public static MateAbstractNode createForNode(AbstractWriteFieldNode node){
@@ -99,7 +99,7 @@ public abstract class MateAbstractExpressionNode extends ExpressionNode {
     @Child protected MateDispatchMessageLookup mateDispatch;
 
     public MateMessageSendNode(final ExpressionWithReceiverNode node) {
-      super(node);
+      super(node.getSourceSection());
       mateDispatch = MateDispatchMessageLookupNodeGen.create(node);
     }
 
@@ -122,7 +122,7 @@ public abstract class MateAbstractExpressionNode extends ExpressionNode {
     @Child protected MateDispatchFieldAccess mateDispatch;
 
     public MateFieldNode(final FieldNode node) {
-      super(node);
+      super(node.getSourceSection());
       mateDispatch = MateDispatchFieldAccessNodeGen.create(node);
     }
 

--- a/MateExtensions/som/interpreter/nodes/MateAbstractExpressionNode.java
+++ b/MateExtensions/som/interpreter/nodes/MateAbstractExpressionNode.java
@@ -24,7 +24,7 @@ import com.oracle.truffle.api.nodes.Node;
   @NodeChild(value = "environment", type = MateEnvironmentSemanticCheckNode.class),
   @NodeChild(value = "object", type = MateObjectSemanticCheckNode.class, executeWith="receiver")
 })
-public abstract class MateAbstractExpressionNode extends ExpressionNode{
+public abstract class MateAbstractExpressionNode extends ExpressionNode {
 
   protected Object doMateDispatchNode(final VirtualFrame frame, final SMateEnvironment environment, final SObject receiver){return null;}
   protected Object doBaseSOMNode(final VirtualFrame frame){return null;}

--- a/MateExtensions/som/interpreter/nodes/MateAbstractReflectiveDispatch.java
+++ b/MateExtensions/som/interpreter/nodes/MateAbstractReflectiveDispatch.java
@@ -28,12 +28,13 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.impl.DefaultTruffleRuntime;
 import com.oracle.truffle.api.nodes.DirectCallNode;
 import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.source.SourceSection;
 import com.oracle.truffle.api.utilities.ValueProfile;
 
 public abstract class MateAbstractReflectiveDispatch extends Node {
-  
-  public MateAbstractReflectiveDispatch(Node node){
-    super(node.getSourceSection());
+
+  public MateAbstractReflectiveDispatch(final SourceSection source){
+    super(source);
   }
   
   /*public Object[] evaluateArguments(final VirtualFrame frame) {
@@ -53,8 +54,8 @@ public abstract class MateAbstractReflectiveDispatch extends Node {
   protected abstract ReflectiveOp getReflectiveOperation();
   
   public abstract static class MateDispatchFieldAccessor extends MateAbstractReflectiveDispatch {
-    public MateDispatchFieldAccessor(FieldAccessorNode node) {
-      super(node);
+    public MateDispatchFieldAccessor(final SourceSection source) {
+      super(source);
     }
     
     public abstract Object executeDispatch(final VirtualFrame frame, Object environment, Object[] arguments);
@@ -86,9 +87,9 @@ public abstract class MateAbstractReflectiveDispatch extends Node {
   
   public abstract static class MateDispatchFieldReadLayout extends MateDispatchFieldAccessor {
     @Child protected AbstractReadFieldNode wrappedNode;
-    
-    public MateDispatchFieldReadLayout(AbstractReadFieldNode node) {
-      super(node);
+
+    public MateDispatchFieldReadLayout(final AbstractReadFieldNode node) {
+      super(node.getSourceSection());
       wrappedNode = node;
     }
     
@@ -104,9 +105,9 @@ public abstract class MateAbstractReflectiveDispatch extends Node {
   
   public abstract static class MateDispatchFieldWriteLayout extends MateDispatchFieldAccessor {
     @Child protected AbstractWriteFieldNode wrappedNode;
-    
-    public MateDispatchFieldWriteLayout(AbstractWriteFieldNode node) {
-      super(node);
+
+    public MateDispatchFieldWriteLayout(final AbstractWriteFieldNode node) {
+      super(node.getSourceSection());
       wrappedNode = node;
     }
     
@@ -122,9 +123,9 @@ public abstract class MateAbstractReflectiveDispatch extends Node {
   
   public abstract static class MateDispatchFieldAccess extends MateAbstractReflectiveDispatch {
     @Child protected FieldNode wrappedNode;
-    
-    public MateDispatchFieldAccess(FieldNode node) {
-      super(node);
+
+    public MateDispatchFieldAccess(final FieldNode node) {
+      super(node.getSourceSection());
       wrappedNode = node;
     }
     
@@ -163,9 +164,9 @@ public abstract class MateAbstractReflectiveDispatch extends Node {
   public abstract static class MateDispatchMessageLookup extends MateAbstractReflectiveDispatch {
     @Child protected ExpressionWithReceiverNode wrappedNode;
     @Child MateDispatchActivation activationDispatch;
-    
-    public MateDispatchMessageLookup(ExpressionWithReceiverNode node) {
-      super(node);
+
+    public MateDispatchMessageLookup(final ExpressionWithReceiverNode node) {
+      super(node.getSourceSection());
       this.wrappedNode = node;
       activationDispatch = MateDispatchActivationNodeGen.create(node);
     }
@@ -214,10 +215,10 @@ public abstract class MateAbstractReflectiveDispatch extends Node {
   
   public abstract static class MateDispatchActivation extends MateAbstractReflectiveDispatch {
     protected final ExpressionWithReceiverNode wrappedNode;
-    
-    public MateDispatchActivation(ExpressionWithReceiverNode node) {
-      super(node);
-      wrappedNode = node; 
+
+    public MateDispatchActivation(final ExpressionWithReceiverNode node) {
+      super(node.getSourceSection());
+      wrappedNode = node;
     }
     
     public abstract Object executeDispatch(final VirtualFrame frame, SMateEnvironment environment, Object receiver, SMethod methodToCall);

--- a/MateExtensions/som/interpreter/nodes/MateAbstractReflectiveDispatch.java
+++ b/MateExtensions/som/interpreter/nodes/MateAbstractReflectiveDispatch.java
@@ -3,7 +3,6 @@ package som.interpreter.nodes;
 import som.interpreter.SArguments;
 import som.interpreter.nodes.MateAbstractReflectiveDispatchFactory.MateDispatchActivationNodeGen;
 import som.interpreter.nodes.MessageSendNode.AbstractMessageSendNode;
-import som.interpreter.objectstorage.FieldAccessorNode;
 import som.interpreter.objectstorage.FieldAccessorNode.AbstractReadFieldNode;
 import som.interpreter.objectstorage.FieldAccessorNode.AbstractWriteFieldNode;
 import som.vm.MateUniverse;
@@ -36,38 +35,38 @@ public abstract class MateAbstractReflectiveDispatch extends Node {
   public MateAbstractReflectiveDispatch(final SourceSection source){
     super(source);
   }
-  
+
   /*public Object[] evaluateArguments(final VirtualFrame frame) {
     Object[] receiver = new Object[1];
     receiver[0] = SArguments.rcvr(frame);
     return receiver;
   }*/
-       
-  public DirectCallNode createDispatch(SMateEnvironment metaobject){
+
+  public DirectCallNode createDispatch(final SMateEnvironment metaobject){
     SInvokable target = metaobject.methodImplementing(this.getReflectiveOperation());
     if (target != null){
        return MateUniverse.current().getTruffleRuntime().createDirectCallNode(target.getCallTarget());
     }
     return null;
   }
-  
+
   protected abstract ReflectiveOp getReflectiveOperation();
-  
+
   public abstract static class MateDispatchFieldAccessor extends MateAbstractReflectiveDispatch {
     public MateDispatchFieldAccessor(final SourceSection source) {
       super(source);
     }
-    
+
     public abstract Object executeDispatch(final VirtualFrame frame, Object environment, Object[] arguments);
-    public Object doWrappedNode(Object[] arguments){return null;}
-     
+    public Object doWrappedNode(final Object[] arguments){return null;}
+
     @Specialization(guards = "cachedEnvironment==environment")
-    public Object doMateNode(final VirtualFrame frame,  
-        SMateEnvironment environment,
-        Object[] arguments,
-        @Cached("environment") SMateEnvironment cachedEnvironment,
-        @Cached("createDispatch(environment)") DirectCallNode reflectiveMethod) 
-    { 
+    public Object doMateNode(final VirtualFrame frame,
+        final SMateEnvironment environment,
+        final Object[] arguments,
+        @Cached("environment") final SMateEnvironment cachedEnvironment,
+        @Cached("createDispatch(environment)") final DirectCallNode reflectiveMethod)
+    {
         if (reflectiveMethod != null) {
           MateUniverse.current().enterMetaExecutionLevel();
           Object value = reflectiveMethod.call(frame, arguments);
@@ -76,15 +75,16 @@ public abstract class MateAbstractReflectiveDispatch extends Node {
         }
         return doSomNode(frame, environment, arguments);
     }
-    
+
     @Specialization(guards= "environment == null")
-    public Object doSomNode(final VirtualFrame frame, Object environment, Object[] arguments){ 
+    public Object doSomNode(final VirtualFrame frame, final Object environment, final Object[] arguments){
         return this.doWrappedNode(arguments);
     }
-    
+
+    @Override
     protected ReflectiveOp getReflectiveOperation(){return null;}
   }
-  
+
   public abstract static class MateDispatchFieldReadLayout extends MateDispatchFieldAccessor {
     @Child protected AbstractReadFieldNode wrappedNode;
 
@@ -92,17 +92,18 @@ public abstract class MateAbstractReflectiveDispatch extends Node {
       super(node.getSourceSection());
       wrappedNode = node;
     }
-    
+
+    @Override
     protected ReflectiveOp getReflectiveOperation(){
       return this.wrappedNode.reflectiveOperation();
     }
-    
+
     @Override
-    public Object doWrappedNode(Object[] arguments){
+    public Object doWrappedNode(final Object[] arguments){
       return this.wrappedNode.read((SObject)arguments[0]);
     }
   }
-  
+
   public abstract static class MateDispatchFieldWriteLayout extends MateDispatchFieldAccessor {
     @Child protected AbstractWriteFieldNode wrappedNode;
 
@@ -110,17 +111,18 @@ public abstract class MateAbstractReflectiveDispatch extends Node {
       super(node.getSourceSection());
       wrappedNode = node;
     }
-    
+
     @Override
-    public Object doWrappedNode(Object[] arguments){
+    public Object doWrappedNode(final Object[] arguments){
       return this.wrappedNode.write((SObject)arguments[0], arguments[2]);
     }
-    
+
+    @Override
     protected ReflectiveOp getReflectiveOperation(){
       return this.wrappedNode.reflectiveOperation();
-    }  
+    }
   }
-  
+
   public abstract static class MateDispatchFieldAccess extends MateAbstractReflectiveDispatch {
     @Child protected FieldNode wrappedNode;
 
@@ -128,39 +130,40 @@ public abstract class MateAbstractReflectiveDispatch extends Node {
       super(node.getSourceSection());
       wrappedNode = node;
     }
-    
+
     public abstract Object executeDispatch(final VirtualFrame frame, Object environment, Object receiver);
-    
+
     @Specialization(guards= "environment == null")
-    public Object doSomNode(final VirtualFrame frame, Object environment, Object receiver){
+    public Object doSomNode(final VirtualFrame frame, final Object environment, final Object receiver){
       return this.doWrappedNode(frame);
     }
-    
+
     @Specialization(guards = {"cachedEnvironment==environment"})
-    public Object doMetaLevel(final VirtualFrame frame,  
-        SMateEnvironment environment,
-        SObject receiver,
-        @Cached("environment") SMateEnvironment cachedEnvironment,
-        @Cached("createDispatch(environment)") DirectCallNode reflectiveMethod) 
-    { 
+    public Object doMetaLevel(final VirtualFrame frame,
+        final SMateEnvironment environment,
+        final SObject receiver,
+        @Cached("environment") final SMateEnvironment cachedEnvironment,
+        @Cached("createDispatch(environment)") final DirectCallNode reflectiveMethod)
+    {
         if (reflectiveMethod != null){
           MateUniverse.current().enterMetaExecutionLevel();
           Object value = reflectiveMethod.call(frame, this.wrappedNode.argumentsForReceiver(frame, receiver));
           MateUniverse.current().leaveMetaExecutionLevel();
           return value;
         }
-        return this.doWrappedNode(frame); 
+        return this.doWrappedNode(frame);
     }
-    
+
     public Object doWrappedNode(final VirtualFrame frame){
       return this.wrappedNode.executeGeneric(frame);
     }
-    
+
+    @Override
     protected ReflectiveOp getReflectiveOperation(){
       return this.wrappedNode.reflectiveOperation();
-    }  
-  }  
-  
+    }
+  }
+
   public abstract static class MateDispatchMessageLookup extends MateAbstractReflectiveDispatch {
     @Child protected ExpressionWithReceiverNode wrappedNode;
     @Child MateDispatchActivation activationDispatch;
@@ -170,21 +173,21 @@ public abstract class MateAbstractReflectiveDispatch extends Node {
       this.wrappedNode = node;
       activationDispatch = MateDispatchActivationNodeGen.create(node);
     }
-    
+
     public abstract Object executeDispatch(final VirtualFrame frame, Object environment, Object receiver);
-    
+
     @Specialization(guards= "environment == null")
-    public Object doSomNode(final VirtualFrame frame, Object environment, Object receiver){
+    public Object doSomNode(final VirtualFrame frame, final Object environment, final Object receiver){
       return this.doWrappedNode(frame);
     }
-    
+
     @Specialization(guards = {"(cachedEnvironment==environment)"})
-    public Object doMetaLevel(final VirtualFrame frame,  
-        SMateEnvironment environment,
-        SObject receiver,
-        @Cached("environment") SMateEnvironment cachedEnvironment,
-        @Cached("createDispatch(environment)") DirectCallNode reflectiveMethod) 
-    { 
+    public Object doMetaLevel(final VirtualFrame frame,
+        final SMateEnvironment environment,
+        final SObject receiver,
+        @Cached("environment") final SMateEnvironment cachedEnvironment,
+        @Cached("createDispatch(environment)") final DirectCallNode reflectiveMethod)
+    {
         if (reflectiveMethod != null){
           //The MOP receives the class where the lookup must start (find: aSelector since: aClass)
           MateUniverse.current().enterMetaExecutionLevel();
@@ -195,24 +198,25 @@ public abstract class MateAbstractReflectiveDispatch extends Node {
         }
         return this.doWrappedNode(frame);
     }
-    
+
+    @Override
     protected ReflectiveOp getReflectiveOperation(){
       return this.wrappedNode.reflectiveOperation();
     }
-    
+
     public AbstractMessageSendNode getSOMWrappedNode(){
       return (AbstractMessageSendNode)this.wrappedNode;
     }
-    
+
     protected SSymbol getSelector(){
       return ((AbstractMessageSendNode)this.wrappedNode).getSelector();
     }
-    
+
     public Object doWrappedNode (final VirtualFrame frame){
       return this.wrappedNode.executeGeneric(frame);
     }
   }
-  
+
   public abstract static class MateDispatchActivation extends MateAbstractReflectiveDispatch {
     protected final ExpressionWithReceiverNode wrappedNode;
 
@@ -220,27 +224,28 @@ public abstract class MateAbstractReflectiveDispatch extends Node {
       super(node.getSourceSection());
       wrappedNode = node;
     }
-    
+
     public abstract Object executeDispatch(final VirtualFrame frame, SMateEnvironment environment, Object receiver, SMethod methodToCall);
-    
+
+    @Override
     protected ReflectiveOp getReflectiveOperation(){
       return ReflectiveOp.Activation;
-    }  
+    }
 
     @Specialization(guards= "environment == null")
-    public Object doSomNode(final VirtualFrame frame, SMateEnvironment environment, SObject receiver, SMethod methodToCall){
+    public Object doSomNode(final VirtualFrame frame, final SMateEnvironment environment, final SObject receiver, final SMethod methodToCall){
       return methodToCall.getCallTarget().call(((PreevaluatedExpression) wrappedNode).evaluateArguments(frame));
     }
-    
+
     /*Todo: Optimize: Isn't the operation always fixes*/
     @Specialization(guards = "(cachedEnvironment==environment)")
-    public Object doMetaLevel(final VirtualFrame frame,  
-        SMateEnvironment environment,
-        SObject receiver,
-        SMethod methodToCall,
-        @Cached("environment") SMateEnvironment cachedEnvironment,
-        @Cached("createDispatch(environment)") DirectCallNode reflectiveMethod) 
-    { 
+    public Object doMetaLevel(final VirtualFrame frame,
+        final SMateEnvironment environment,
+        final SObject receiver,
+        final SMethod methodToCall,
+        @Cached("environment") final SMateEnvironment cachedEnvironment,
+        @Cached("createDispatch(environment)") final DirectCallNode reflectiveMethod)
+    {
       Object[] arguments = ((PreevaluatedExpression) wrappedNode).evaluateArguments(frame);
       if (reflectiveMethod != null){
         //The MOP receives the standard ST message Send stack (rcvr, selector, arguments) and return its own
@@ -260,41 +265,45 @@ public abstract class MateAbstractReflectiveDispatch extends Node {
           } finally {
             runtime.popFrame();
           }
-        }  
+        }
         return methodToCall.getCallTarget().call(realArguments);
       } else {
         return methodToCall.getCallTarget().call(arguments);
       }
     }
-    
-    private Object[] gatherArrayFromSArray(SArray array){
+
+    private Object[] gatherArrayFromSArray(final SArray array){
       if (array.getType() == ArrayType.PARTIAL_EMPTY){
         return array.getPartiallyEmptyStorage(ValueProfile.createClassProfile()).getStorage();
       } else {
         return array.getObjectStorage(ValueProfile.createClassProfile());
       }
     }
-    
-    private FrameInstance frameInstanceFor(VirtualFrame frame, SMethod method){
+
+    private FrameInstance frameInstanceFor(final VirtualFrame frame, final SMethod method){
       return new FrameInstance() {
-        public Frame getFrame(FrameAccess access, boolean slowPath) {
+        @Override
+        public Frame getFrame(final FrameAccess access, final boolean slowPath) {
             return frame;
         }
 
+        @Override
         public boolean isVirtualFrame() {
             return false;
         }
 
+        @Override
         public Node getCallNode() {
             return method.getCallTarget().getRootNode();
         }
 
+        @Override
         public CallTarget getCallTarget() {
             return method.getCallTarget();
         }
       };
     }
-    private VirtualFrame newFrameWithRedefinedSemanticsFor(Object[] arguments, SMethod methodToCall, SMateEnvironment environment, DefaultTruffleRuntime runtime){
+    private VirtualFrame newFrameWithRedefinedSemanticsFor(final Object[] arguments, final SMethod methodToCall, final SMateEnvironment environment, final DefaultTruffleRuntime runtime){
       VirtualFrame customizedFrame = runtime.createVirtualFrame(arguments, methodToCall.getCallTarget().getRootNode().getFrameDescriptor());
       FrameSlot slot = customizedFrame.getFrameDescriptor().addFrameSlot("semantics", FrameSlotKind.Object);
       customizedFrame.setObject(slot, environment);

--- a/src/som/interpreter/nodes/ExpressionWithReceiverNode.java
+++ b/src/som/interpreter/nodes/ExpressionWithReceiverNode.java
@@ -1,13 +1,11 @@
 package som.interpreter.nodes;
 
-import som.interpreter.nodes.MateAbstractExpressionNodeGen.MateFieldNodeGen;
 import som.interpreter.nodes.MateAbstractExpressionNodeGen.MateMessageSendNodeGen;
 import som.interpreter.nodes.MateAbstractReceiverNode.MateReceiverExpressionNode;
 import som.interpreter.nodes.MateAbstractSemanticCheckNodeFactory.MateEnvironmentSemanticCheckNodeGen;
 import som.interpreter.nodes.MateAbstractSemanticCheckNodeFactory.MateObjectSemanticCheckNodeGen;
 
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.source.SourceSection;
 
 
@@ -24,17 +22,11 @@ public abstract class ExpressionWithReceiverNode extends ExpressionNode {
   }
 
   @Override
-  public Node wrapIntoMateNode(){
-    if (this instanceof FieldNode){
-      return MateFieldNodeGen.create((FieldNode) this,
-          new MateReceiverExpressionNode(this),
-          MateEnvironmentSemanticCheckNodeGen.create(),
-          MateObjectSemanticCheckNodeGen.create());
-    }
-    return MateMessageSendNodeGen.create(this,
+  public void wrapIntoMateNode() {
+    replace(MateMessageSendNodeGen.create(this,
         new MateReceiverExpressionNode(this),
         MateEnvironmentSemanticCheckNodeGen.create(),
-        MateObjectSemanticCheckNodeGen.create());
+        MateObjectSemanticCheckNodeGen.create()));
   }
 }
 

--- a/src/som/interpreter/nodes/FieldNode.java
+++ b/src/som/interpreter/nodes/FieldNode.java
@@ -21,6 +21,10 @@
  */
 package som.interpreter.nodes;
 
+import som.interpreter.nodes.MateAbstractExpressionNodeGen.MateFieldNodeGen;
+import som.interpreter.nodes.MateAbstractReceiverNode.MateReceiverExpressionNode;
+import som.interpreter.nodes.MateAbstractSemanticCheckNodeFactory.MateEnvironmentSemanticCheckNodeGen;
+import som.interpreter.nodes.MateAbstractSemanticCheckNodeFactory.MateObjectSemanticCheckNodeGen;
 import som.interpreter.objectstorage.FieldAccessorNode.AbstractReadFieldNode;
 import som.interpreter.objectstorage.FieldAccessorNode.AbstractWriteFieldNode;
 import som.interpreter.objectstorage.FieldAccessorNode.UninitializedReadFieldNode;
@@ -44,7 +48,15 @@ public abstract class FieldNode extends ExpressionWithReceiverNode {
 
   protected abstract ExpressionNode getSelf();
   public abstract Object[] argumentsForReceiver(final VirtualFrame frame, SObject receiver);
-  
+
+  @Override
+  public void wrapIntoMateNode() {
+    replace(MateFieldNodeGen.create((FieldNode) this,
+        new MateReceiverExpressionNode(this),
+        MateEnvironmentSemanticCheckNodeGen.create(),
+        MateObjectSemanticCheckNodeGen.create()));
+  }
+
   public Object[] evaluateArguments(final VirtualFrame frame) {
     SObject object;
     try {

--- a/src/som/interpreter/nodes/FieldNode.java
+++ b/src/som/interpreter/nodes/FieldNode.java
@@ -67,12 +67,12 @@ public abstract class FieldNode extends ExpressionWithReceiverNode {
     }
     return this.argumentsForReceiver(frame, object);
   }
-  
+
   public static final class FieldReadNode extends FieldNode
       implements PreevaluatedExpression {
     @Child private ExpressionNode self;
     @Child private AbstractReadFieldNode read;
-   
+
     public FieldReadNode(final ExpressionNode self, final int fieldIndex,
         final SourceSection source) {
       super(source);
@@ -112,7 +112,7 @@ public abstract class FieldNode extends ExpressionWithReceiverNode {
     }
 
     @Override
-    public Object[] argumentsForReceiver(VirtualFrame frame, SObject receiver) {
+    public Object[] argumentsForReceiver(final VirtualFrame frame, final SObject receiver) {
       Object[] arguments = new Object[2];
       arguments[0] = receiver;
       arguments[1] = this.read.getFieldIndex();

--- a/src/som/interpreter/nodes/SOMNode.java
+++ b/src/som/interpreter/nodes/SOMNode.java
@@ -23,6 +23,7 @@ package som.interpreter.nodes;
 
 import som.interpreter.InlinerAdaptToEmbeddedOuterContext;
 import som.interpreter.InlinerForLexicallyEmbeddedMethods;
+import som.interpreter.MateNode;
 import som.interpreter.SplitterForLexicallyEmbeddedCode;
 import som.interpreter.Types;
 
@@ -31,7 +32,7 @@ import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.source.SourceSection;
 
 @TypeSystemReference(Types.class)
-public abstract class SOMNode extends Node {
+public abstract class SOMNode extends Node implements MateNode {
 
   public SOMNode(final SourceSection sourceSection) {
     super(sourceSection);
@@ -88,8 +89,10 @@ public abstract class SOMNode extends Node {
    * @return body of a node that just wraps the actual method body.
    */
   public abstract ExpressionNode getFirstMethodBodyNode();
-  
-  public Node wrapIntoMateNode(){
-    return this;
+
+  @Override
+  public void wrapIntoMateNode() {
+    // do nothing!
+    // only a small subset of nodes needs to implement this method.
   }
 }

--- a/src/som/interpreter/nodes/SequenceNode.java
+++ b/src/som/interpreter/nodes/SequenceNode.java
@@ -23,7 +23,6 @@ package som.interpreter.nodes;
 
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
-import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.NodeCost;
 import com.oracle.truffle.api.nodes.NodeInfo;
 import com.oracle.truffle.api.source.SourceSection;
@@ -48,9 +47,5 @@ public final class SequenceNode extends ExpressionNode {
     for (int i = 0; i < expressions.length - 1; i++) {
       expressions[i].executeGeneric(frame);
     }
-  }
-  
-  public Node wrapIntoMateNode(){
-    return this;
   }
 }

--- a/src/som/interpreter/nodes/specialized/whileloops/WhileCache.java
+++ b/src/som/interpreter/nodes/specialized/whileloops/WhileCache.java
@@ -11,7 +11,6 @@ import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.nodes.Node;
 
 
 public abstract class WhileCache extends BinaryExpressionNode {
@@ -66,5 +65,10 @@ public abstract class WhileCache extends BinaryExpressionNode {
       loopConditionResult = obj2bool(conditionResult);
     }
     return Nil.nilObject;
+  }
+
+  @Override
+  public void wrapIntoMateNode() {
+    // do nothing, don't want to do the same as for other nodes with receiver
   }
 }

--- a/src/som/interpreter/objectstorage/FieldAccessorNode.java
+++ b/src/som/interpreter/objectstorage/FieldAccessorNode.java
@@ -35,9 +35,9 @@ public abstract class FieldAccessorNode extends Node implements MateNode {
   public final int getFieldIndex() {
     return fieldIndex;
   }
-  
+
   public abstract ReflectiveOp reflectiveOperation();
-  
+
   public abstract static class AbstractReadFieldNode extends FieldAccessorNode {
     public AbstractReadFieldNode(final int fieldIndex) {
       super(fieldIndex);
@@ -91,7 +91,8 @@ public abstract class FieldAccessorNode extends Node implements MateNode {
     public void wrapIntoMateNode(){
       replace(new MateFieldReadNode(this));
     }
-    
+
+    @Override
     public ReflectiveOp reflectiveOperation(){
       return ReflectiveOp.ReadLayout;
     }
@@ -214,7 +215,7 @@ public abstract class FieldAccessorNode extends Node implements MateNode {
     public ReadObjectFieldNode(final int fieldIndex, final Shape layout,
         final AbstractReadFieldNode next) {
       super(fieldIndex, layout, next);
-      this.storage = (Location) layout.getProperty(fieldIndex).getLocation();
+      this.storage = layout.getProperty(fieldIndex).getLocation();
     }
 
     @Override
@@ -279,7 +280,8 @@ public abstract class FieldAccessorNode extends Node implements MateNode {
     public void wrapIntoMateNode(){
       replace(new MateFieldWriteNode(this));
     }
-    
+
+    @Override
     public ReflectiveOp reflectiveOperation(){
       return ReflectiveOp.WriteLayout;
     }

--- a/src/som/interpreter/objectstorage/FieldAccessorNode.java
+++ b/src/som/interpreter/objectstorage/FieldAccessorNode.java
@@ -1,5 +1,6 @@
 package som.interpreter.objectstorage;
 
+import som.interpreter.MateNode;
 import som.interpreter.TruffleCompiler;
 import som.interpreter.TypesGen;
 import som.vm.constants.Nil;
@@ -16,7 +17,7 @@ import com.oracle.truffle.api.object.Location;
 import com.oracle.truffle.api.object.LongLocation;
 import com.oracle.truffle.api.object.Shape;
 
-public abstract class FieldAccessorNode extends Node {
+public abstract class FieldAccessorNode extends Node implements MateNode {
   protected final int fieldIndex;
 
   public static AbstractReadFieldNode createRead(final int fieldIndex) {
@@ -85,9 +86,10 @@ public abstract class FieldAccessorNode extends Node {
       //}
       return replace(newNode, reason);
     }
-    
-    public Node wrapIntoMateNode(){
-      return new MateFieldReadNode(this);
+
+    @Override
+    public void wrapIntoMateNode(){
+      replace(new MateFieldReadNode(this));
     }
     
     public ReflectiveOp reflectiveOperation(){
@@ -272,9 +274,10 @@ public abstract class FieldAccessorNode extends Node {
       //}
       replace(newNode, reason);
     }
-    
-    public Node wrapIntoMateNode(){
-      return new MateFieldWriteNode(this);
+
+    @Override
+    public void wrapIntoMateNode(){
+      replace(new MateFieldWriteNode(this));
     }
     
     public ReflectiveOp reflectiveOperation(){

--- a/src/som/primitives/GlobalPrim.java
+++ b/src/som/primitives/GlobalPrim.java
@@ -14,7 +14,6 @@ import som.vmobjects.SSymbol;
 import com.oracle.truffle.api.dsl.ImportStatic;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.nodes.Node;
 
 
 @ImportStatic(SystemPrims.class)
@@ -24,6 +23,11 @@ public abstract class GlobalPrim extends BinarySystemNode {
   @Specialization(guards = "receiverIsSystemObject(receiver)")
   public final Object doSObject(final VirtualFrame frame, final SObject receiver, final SSymbol argument) {
     return getGlobal.getGlobal(frame, argument);
+  }
+
+  @Override
+  public void wrapIntoMateNode() {
+    // do nothing
   }
 
   private abstract static class GetGlobalNode extends SOMNode {
@@ -36,10 +40,6 @@ public abstract class GlobalPrim extends BinarySystemNode {
     @Override
     public ExpressionNode getFirstMethodBodyNode() {
       throw new NotYetImplementedException();
-    }
-    
-    public Node wrapIntoMateNode(){
-      return this;
     }
   }
 

--- a/src/som/primitives/HasGlobalPrim.java
+++ b/src/som/primitives/HasGlobalPrim.java
@@ -10,7 +10,6 @@ import som.vmobjects.SSymbol;
 
 import com.oracle.truffle.api.dsl.ImportStatic;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.nodes.Node;
 
 @ImportStatic(SystemPrims.class)
 public abstract class HasGlobalPrim extends BinarySystemNode {
@@ -37,9 +36,10 @@ public abstract class HasGlobalPrim extends BinarySystemNode {
     public ExpressionNode getFirstMethodBodyNode() {
       throw new NotYetImplementedException();
     }
-    
-    public Node wrapIntoMateNode(){
-      return this;
+
+    @Override
+    public void wrapIntoMateNode() {
+      // do nothing, don't want to do the same as for other nodes with receiver
     }
   }
 

--- a/src/som/primitives/reflection/PerformInSuperclassPrim.java
+++ b/src/som/primitives/reflection/PerformInSuperclassPrim.java
@@ -25,4 +25,9 @@ public abstract class PerformInSuperclassPrim extends TernaryExpressionNode {
     SInvokable invokable = clazz.lookupInvokable(selector);
     return call.call(frame, invokable.getCallTarget(), new Object[] {receiver});
   }
+
+  @Override
+  public void wrapIntoMateNode() {
+    // do nothing
+  }
 }

--- a/src/som/primitives/reflection/PerformWithArgumentsPrim.java
+++ b/src/som/primitives/reflection/PerformWithArgumentsPrim.java
@@ -29,4 +29,9 @@ public abstract class PerformWithArgumentsPrim extends TernaryExpressionNode {
   public NodeCost getCost() {
     return dispatch.getCost();
   }
+
+  @Override
+  public void wrapIntoMateNode() {
+    // do nothing
+  }
 }


### PR DESCRIPTION
On the hunt for the stabilizing issue, I did some refactoring.

First, I did move the Mateify to the same approach I use for the inlining of nodes.
So, there is one polymorphic method, nodes have to implement. I realized that by adding a `MateNode` interface. Now, there are no `instanceof` tests left anymore. And the nodes are consistently responsible for doing the appropriate transformation. Instead having it in two or three places.

The second thing I change is to pass the SourceSection, instead of passing the node, where possible.

The underlying issue why the tree does not stableize is that you pass nodes two more than one node, and try to integrate them there. However, a node can only have a single parent.
This means, they can't be in the tree more than once.

I am not entirely sure why you think it is necessary to have it twice. But, if it is really necessary, we need a way to obtain the reference, instead of having the node in two `@Child` fields.

So, code like this cannot work:

``` java
  @Override
  public void wrapIntoMateNode() {
    replace(MateMessageSendNodeGen.create(this, // one this
        new MateReceiverExpressionNode(this),   // a second this
        MateEnvironmentSemanticCheckNodeGen.create(),
        MateObjectSemanticCheckNodeGen.create()));
  }
```

Those two `this` references need to be avoided.
