### PR TITLE
Fix subtle bug. Since uninitializedBody was not being cloned, when th…

### DIFF
--- a/src/som/interpreter/Method.java
+++ b/src/som/interpreter/Method.java
@@ -21,15 +21,15 @@
  */
 package som.interpreter;
 
-import som.interpreter.nodes.ExpressionNode;
-import som.interpreter.nodes.SOMNode;
-
 import com.oracle.truffle.api.frame.FrameDescriptor;
 import com.oracle.truffle.api.nodes.LoopNode;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.NodeUtil;
 import com.oracle.truffle.api.object.DynamicObject;
 import com.oracle.truffle.api.source.SourceSection;
+
+import som.interpreter.nodes.ExpressionNode;
+import som.interpreter.nodes.SOMNode;
 
 
 public final class Method extends Invokable {
@@ -113,7 +113,9 @@ public final class Method extends Invokable {
 
   @Override
   public Node deepCopy() {
-    return cloneWithNewLexicalContext(currentLexicalScope.getOuterScopeOrNull());
+    Node copy = cloneWithNewLexicalContext(currentLexicalScope.getOuterScopeOrNull());
+    ((Invokable) copy).uninitializedBody = (ExpressionNode) uninitializedBody.deepCopy();
+    return copy;
   }
 
   public boolean isBlock() {


### PR DESCRIPTION
…e compiler splits the node it always clone a version with the intercession handling activated. We do not want that in the case we are executing a method at the meta level. So I clone the uninitializedBody too